### PR TITLE
Add requirements of `rspec_passed_time_formatter`

### DIFF
--- a/gems.locked
+++ b/gems.locked
@@ -105,6 +105,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.0)
+    rspec_passed_time_formatter (0.2.0)
     rubocop (1.5.2)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
@@ -147,6 +148,7 @@ DEPENDENCIES
   ooxml_parser
   palladium!
   rspec
+  rspec_passed_time_formatter
   rubocop
   rubocop-performance
   rubocop-rspec

--- a/gems.rb
+++ b/gems.rb
@@ -11,6 +11,7 @@ gem 'onlyoffice_webdriver_wrapper'
 gem 'ooxml_parser'
 gem 'palladium', git: 'https://github.com/flaminestone/palladium.git'
 gem 'rspec'
+gem 'rspec_passed_time_formatter'
 gem 'rubocop', require: false
 gem 'rubocop-performance', require: false
 gem 'rubocop-rspec', require: false


### PR DESCRIPTION
This gem is required for correct run of tests, since this change:
https://github.com/ONLYOFFICE/testing-wrata/pull/857