### PR TITLE
Replace `PageObject#visible?` to `PageObject#present?`

### DIFF
--- a/lib/testing_api_onlyoffice_com/test_instance/main_page.rb
+++ b/lib/testing_api_onlyoffice_com/test_instance/main_page.rb
@@ -28,11 +28,11 @@ module TestingApiOnlyfficeCom
     end
 
     def sidebar_visible?
-      sidebar_element.visible?
+      sidebar_element.present?
     end
 
     def portals_api_visible?
-      portals_element.visible?
+      portals_element.present?
     end
 
     def go_to_community_server_api

--- a/lib/testing_api_onlyoffice_com/test_instance/main_page/community_server_api.rb
+++ b/lib/testing_api_onlyoffice_com/test_instance/main_page/community_server_api.rb
@@ -18,7 +18,7 @@ module TestingApiOnlyfficeCom
     end
 
     def wait_to_load
-      @instance.webdriver.wait_until { identification_element.visible? }
+      @instance.webdriver.wait_until { identification_element.present? }
     end
 
     def navigation_objects

--- a/lib/testing_api_onlyoffice_com/test_instance/main_page/document_builder_api/document_builder_api_common/builder_page.rb
+++ b/lib/testing_api_onlyoffice_com/test_instance/main_page/document_builder_api/document_builder_api_common/builder_page.rb
@@ -29,7 +29,7 @@ module TestingApiOnlyfficeCom
     end
 
     def wait_to_load
-      @instance.webdriver.wait_until { integrating_document_builder_element.visible? }
+      @instance.webdriver.wait_until { integrating_document_builder_element.present? }
     end
 
     def open_introduction

--- a/lib/testing_api_onlyoffice_com/test_instance/main_page/document_builder_api/document_builder_api_common/document_builder.rb
+++ b/lib/testing_api_onlyoffice_com/test_instance/main_page/document_builder_api/document_builder_api_common/document_builder.rb
@@ -52,7 +52,7 @@ module TestingApiOnlyfficeCom
     end
 
     def button_generate_document_visible?
-      generate_document_element.visible?
+      generate_document_element.present?
     end
   end
 end

--- a/lib/testing_api_onlyoffice_com/test_instance/main_page/document_builder_api/document_builder_getting_started.rb
+++ b/lib/testing_api_onlyoffice_com/test_instance/main_page/document_builder_api/document_builder_getting_started.rb
@@ -17,7 +17,7 @@ module TestingApiOnlyfficeCom
     end
 
     def wait_to_load
-      @instance.webdriver.wait_until { windows_x86_element.visible? }
+      @instance.webdriver.wait_until { windows_x86_element.present? }
     end
 
     def download_library_linux_x64_works?

--- a/lib/testing_api_onlyoffice_com/test_instance/main_page/document_builder_api/document_builder_integrating.rb
+++ b/lib/testing_api_onlyoffice_com/test_instance/main_page/document_builder_api/document_builder_integrating.rb
@@ -32,15 +32,15 @@ module TestingApiOnlyfficeCom
     end
 
     def wait_to_load
-      @instance.webdriver.wait_until { generate_document_element.visible? }
+      @instance.webdriver.wait_until { generate_document_element.present? }
     end
 
     def check_download_links
       checked = {}
       DOC_BUILDER_EXAMPLES.each do |ex|
         link = send("#{ex}_element")
-        checked["#{ex}_visibility"] = link.visible?
-        checked["#{ex}_downloadable"] = HTTParty.head(link.href).success? if link.visible?
+        checked["#{ex}_visibility"] = link.present?
+        checked["#{ex}_downloadable"] = HTTParty.head(link.href).success? if link.present?
       end
       checked
     end

--- a/lib/testing_api_onlyoffice_com/test_instance/main_page/document_server_api.rb
+++ b/lib/testing_api_onlyoffice_com/test_instance/main_page/document_server_api.rb
@@ -42,7 +42,7 @@ module TestingApiOnlyfficeCom
     end
 
     def wait_to_load
-      @instance.webdriver.wait_until { try_now_element.visible? }
+      @instance.webdriver.wait_until { try_now_element.present? }
     end
 
     def try_now_works?
@@ -66,7 +66,7 @@ module TestingApiOnlyfficeCom
     end
 
     def editor_seems_legit?(editor = :document)
-      send("#{editor}_editor_demo_element").visible? && documents_framework.management.editor_type == editor
+      send("#{editor}_editor_demo_element").present? && documents_framework.management.editor_type == editor
     end
 
     def demo_editor_switch_seems_legit?(editor = :document)
@@ -78,8 +78,8 @@ module TestingApiOnlyfficeCom
       checked = {}
       DOC_SERVER_EXAMPLES.each do |ex|
         link = send("#{ex}_element")
-        checked["#{ex}_visibility"] = link.visible?
-        checked["#{ex}_downloadable"] = HTTParty.head(link.href).success? if link.visible?
+        checked["#{ex}_visibility"] = link.present?
+        checked["#{ex}_downloadable"] = HTTParty.head(link.href).success? if link.present?
       end
       checked
     end


### PR DESCRIPTION
Old variant is deprecated for quite a long time
and resulting a lot of warnings
Something may break, but I'll fix it in future PR