### PR TITLE
feature: pending checked methods

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,24 +18,28 @@ shared_examples_for 'page_content_exist' do |path, documentation_page|
     it "#{path}/Parameters" do
       pending('https://github.com/ONLYOFFICE/api.onlyoffice.com/issues/49') if failed_docbuilder_tests.include?("#{path}/Parameters")
       pending('https://github.com/ONLYOFFICE/api.onlyoffice.com/issues/54') if failed_community_server_tests.include?("#{path}/Parameters")
+      pending('https://github.com/ONLYOFFICE/api.onlyoffice.com/issues/576') if failed_docspace_tests.include?("#{path}/Parameters")
       expect(@documentation_page.params_exist).to be_truthy
     end
 
     it "#{path}/Returns" do
       pending 'https://github.com/ONLYOFFICE/api.onlyoffice.com/issues/49' if failed_docbuilder_tests.include?("#{path}/Returns")
       pending 'https://github.com/ONLYOFFICE/api.onlyoffice.com/issues/54' if failed_community_server_tests.include?("#{path}/Returns")
+      pending('https://github.com/ONLYOFFICE/api.onlyoffice.com/issues/576') if failed_docspace_tests.include?("#{path}/Returns")
       expect(@documentation_page.return_exist).to be_truthy
     end
 
     it "#{path}/Example" do
       pending 'https://github.com/ONLYOFFICE/api.onlyoffice.com/issues/49' if failed_docbuilder_tests.include?("#{path}/Example")
       pending 'https://github.com/ONLYOFFICE/api.onlyoffice.com/issues/54' if failed_community_server_tests.include?("#{path}/Example")
+      pending('https://github.com/ONLYOFFICE/api.onlyoffice.com/issues/576') if failed_docspace_tests.include?("#{path}/Example")
       expect(@documentation_page.example_exist).to be_truthy
     end
 
     it "#{path}/Resulting document" do
       pending 'https://github.com/ONLYOFFICE/api.onlyoffice.com/issues/49' if failed_docbuilder_tests.include?("#{path}/Resulting document")
       pending 'https://github.com/ONLYOFFICE/api.onlyoffice.com/issues/54' if failed_community_server_tests.include?("#{path}/Resulting document")
+      pending('https://github.com/ONLYOFFICE/api.onlyoffice.com/issues/576') if failed_docspace_tests.include?("#{path}/Resulting document")
       expect(@documentation_page.document_exist).to be_truthy
     end
   end
@@ -47,4 +51,8 @@ end
 
 def failed_community_server_tests
   @failed_community_server_tests ||= File.read("#{__dir__}/data/failed_community_server_tests.list").split("\n")
+end
+
+def failed_docspace_tests
+  @failed_docspace_tests ||= File.read("#{__dir__}/data/failed_docspace_tests.list").split("\n")
 end


### PR DESCRIPTION
I checked the manual operation of the docspace api tests on several runs. 

Now the items that are not found will be written to the issue  https://github.com/ONLYOFFICE/api.onlyoffice.com/issues/576

And transfer each version of the documentation to the developers and the technical documentation department