### PR TITLE
Run browser CI check on production `api.onlyoffice.com`

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,5 +22,7 @@ jobs:
           sudo apt-get -y update
           sudo apt-get -y install google-chrome-stable
       - name: Run single browser spec to check sanity
+        env:
+          SPEC_REGION: 'api.onlyoffice.com'
         run: |
           rspec spec/testing-api.onlyoffice.com/languages/chinese_language_spec.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 
 * Remove 'codeclimate` config, since we don't use any more
 * Check `dependabot` at 8:00 Moscow time daily
+* Run browser CI check on production `api.onlyoffice.com`


### PR DESCRIPTION
Until beta of api is released on prod - use prod as test destination in CI

In general we can keep it like that - test should be compatible with prod server and prod server is more stable, so no flaky CI